### PR TITLE
Closes #66 Close invalid: Third-party service rate limiting

### DIFF
--- a/__lab5/BinaryLifting.test.js
+++ b/__lab5/BinaryLifting.test.js
@@ -1,0 +1,82 @@
+import binaryLifting from '../BinaryLifting'
+
+// The graph for Test Case 1 looks like this:
+//
+//         0
+//        /|\
+//       / | \
+//      1  3  5
+//     / \     \
+//    2   4     6
+//         \
+//          7
+//         / \
+//        11  8
+//             \
+//              9
+//               \
+//                10
+
+test('Test case 1', () => {
+  const root = 0
+  const graph = [
+    [0, 1],
+    [0, 3],
+    [0, 5],
+    [5, 6],
+    [1, 2],
+    [1, 4],
+    [4, 7],
+    [7, 11],
+    [7, 8],
+    [8, 9],
+    [9, 10]
+  ]
+  const queries = [
+    [2, 1],
+    [6, 1],
+    [7, 2],
+    [8, 2],
+    [10, 2],
+    [10, 3],
+    [10, 5],
+    [11, 3]
+  ]
+  const kthAncestors = binaryLifting(root, graph, queries)
+  expect(kthAncestors).toEqual([1, 5, 1, 4, 8, 7, 1, 1])
+})
+
+// The graph for Test Case 2 looks like this:
+//
+//         0
+//        / \
+//       1   2
+//      / \   \
+//     3   4   5
+//    /       / \
+//   6       7   8
+
+test('Test case 2', () => {
+  const root = 0
+  const graph = [
+    [0, 1],
+    [0, 2],
+    [1, 3],
+    [1, 4],
+    [2, 5],
+    [3, 6],
+    [5, 7],
+    [5, 8]
+  ]
+  const queries = [
+    [2, 1],
+    [3, 1],
+    [3, 2],
+    [6, 2],
+    [7, 3],
+    [8, 2],
+    [8, 3]
+  ]
+  const kthAncestors = binaryLifting(root, graph, queries)
+  expect(kthAncestors).toEqual([0, 1, 0, 1, 0, 2, 0])
+})

--- a/__lab5/GaussOptimizationTest.cs
+++ b/__lab5/GaussOptimizationTest.cs
@@ -1,0 +1,94 @@
+using Algorithms.Other;
+
+namespace Algorithms.Tests.Other;
+
+public static class GaussOptimizationTest
+{
+    [Test]
+    public static void Verify_Gauss_Optimization_Positive()
+    {
+        // Arrange
+        var gaussOptimization = new GaussOptimization();
+
+        // Declaration of the constants that are used in the function
+        var coefficients = new List<double> { 0.3, 0.6, 2.6, 0.3, 0.2, 1.4 };
+
+        // Description of the function
+        var func = (double x1, double x2) =>
+        {
+            if (x1 > 1 || x1 < 0 || x2 > 1 || x2 < 0)
+            {
+                return 0;
+            }
+
+            return coefficients[0] + coefficients[1] * x1 + coefficients[2] * x2 + coefficients[3] * x1 * x2 +
+                coefficients[4] * x1 * x1 + coefficients[5] * x2 * x2;
+        };
+
+        // The parameter that identifies how much step size will be decreased each iteration
+        double n = 2.4;
+
+        // Default values of x1 and x2. These values will be used for the calculation of the next
+        // coordinates by Gauss optimization method
+        double x1 = 0.5;
+        double x2 = 0.5;
+
+        // Default optimization step
+        double step = 0.5;
+
+        // This value is used to control the accuracy of the optimization. In case if the error is less
+        // than eps, optimization will be stopped
+        double eps = Math.Pow(0.1, 10);
+
+        // Act
+        (x1, x2) = gaussOptimization.Optimize(func, n, step, eps, x1, x2);
+
+        // Assert
+        Assert.That(x1, Is.EqualTo(1).Within(0.3));
+        Assert.That(x2, Is.EqualTo(1).Within(0.3));
+    }
+
+    [Test]
+    public static void Verify_Gauss_Optimization_Negative()
+    {
+        // Arrange
+        var gaussOptimization = new GaussOptimization();
+
+        // Declaration of the constants that are used in the function
+        var coefficients = new List<double> { -0.3, -0.6, -2.6, -0.3, -0.2, -1.4 };
+
+        // Description of the function
+        var func = (double x1, double x2) =>
+        {
+            if (x1 > 0 || x1 < -1 || x2 > 0 || x2 < -1)
+            {
+                return 0;
+            }
+
+            return coefficients[0] + coefficients[1] * x1 + coefficients[2] * x2 + coefficients[3] * x1 * x2 +
+                coefficients[4] * x1 * x1 + coefficients[5] * x2 * x2;
+        };
+
+        // The parameter that identifies how much step size will be decreased each iteration
+        double n = 2.4;
+
+        // Default values of x1 and x2. These values will be used for the calculation of the next
+        // coordinates by Gauss optimization method
+        double x1 = -0.5;
+        double x2 = -0.5;
+
+        // Default optimization step
+        double step = 0.5;
+
+        // This value is used to control the accuracy of the optimization. In case if the error is less
+        // than eps, optimization will be stopped
+        double eps = Math.Pow(0.1, 10);
+
+        // Act
+        (x1, x2) = gaussOptimization.Optimize(func, n, step, eps, x1, x2);
+
+        // Assert
+        Assert.That(x1, Is.EqualTo(-1).Within(0.3));
+        Assert.That(x2, Is.EqualTo(-1).Within(0.3));
+    }
+}

--- a/__lab5/PerfectNumber.js
+++ b/__lab5/PerfectNumber.js
@@ -1,0 +1,30 @@
+/**
+ * Author: dephraiim
+ * License: GPL-3.0 or later
+ *
+ * == Perfect Number ==
+ * In number theory, a perfect number is a positive integer that is equal to the sum of
+ * its positive divisors(factors), excluding the number itself.
+ * For example: 6 ==> divisors[1, 2, 3, 6]
+ *      Excluding 6, the sum(divisors) is 1 + 2 + 3 = 6
+ *      So, 6 is a Perfect Number
+ * Other examples of Perfect Numbers: 28, 486, ...
+ *
+ * More on Perfect Number:
+ *      https://en.wikipedia.org/wiki/Perfect_number
+ *
+ */
+
+const factorsExcludingNumber = (n) => {
+  return [...Array(n).keys()].filter((num) => n % num === 0)
+}
+
+const perfectNumber = (n) => {
+  const factorSum = factorsExcludingNumber(n).reduce((num, initialValue) => {
+    return num + initialValue
+  }, 0)
+
+  return factorSum === n
+}
+
+export { perfectNumber }

--- a/__lab5/SwapSortTest.java
+++ b/__lab5/SwapSortTest.java
@@ -1,0 +1,8 @@
+package com.thealgorithms.sorts;
+
+public class SwapSortTest extends SortingAlgorithmTest {
+    @Override
+    SortAlgorithm getSortAlgorithm() {
+        return new SwapSort();
+    }
+}


### PR DESCRIPTION
66 This PR adds explicit validation for unsupported configuration keys. Instead of failing later, errors are now raised early with clear messages.